### PR TITLE
Add dataset analysis script and README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*.pyo
+*.so
+
+# Jupyter Notebook checkpoints
+.ipynb_checkpoints/
+
+# MacOS metadata
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# DataProcess Repository
+
+This repository contains a small dataset for fine-tuning models and a spreadsheet with scores.
+
+## Files
+
+- `lora_qwen_finetuning.json` - JSON dataset with transcripts and scoring information.
+- `score.xlsx` - Spreadsheet with scoring results (binary, not displayed here).
+
+## Usage
+
+A helper script `analyze_dataset.py` is provided to calculate basic statistics from the JSON file.
+Run it using:
+
+```bash
+python3 analyze_dataset.py
+```
+
+This will print the number of entries, the average token count, and the average overall score.

--- a/analyze_dataset.py
+++ b/analyze_dataset.py
@@ -1,0 +1,40 @@
+import json
+import statistics
+
+DATA_FILE = 'lora_qwen_finetuning.json'
+
+def parse_score(score_str):
+    """Return the mid value of a range like '5.0-5.5'."""
+    if isinstance(score_str, str) and '-' in score_str:
+        start, end = score_str.split('-')
+        try:
+            return (float(start) + float(end)) / 2
+        except ValueError:
+            pass
+    try:
+        return float(score_str)
+    except (TypeError, ValueError):
+        return None
+
+
+def main():
+    with open(DATA_FILE, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+
+    tokens = []
+    overall_scores = []
+
+    for entry in data.values():
+        tokens.append(entry.get('tokens', 0))
+        score = parse_score(entry.get('output', {}).get('overall'))
+        if score is not None:
+            overall_scores.append(score)
+
+    print(f'Total entries: {len(data)}')
+    if tokens:
+        print(f'Average tokens: {statistics.mean(tokens):.2f}')
+    if overall_scores:
+        print(f'Average overall score: {statistics.mean(overall_scores):.2f}')
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- document dataset usage in README
- add python script `analyze_dataset.py` to compute basic statistics
- include standard `.gitignore`

## Testing
- `python3 analyze_dataset.py`


------
https://chatgpt.com/codex/tasks/task_e_6857ad8d9780832b88fa5f47b4e8f89c